### PR TITLE
Update Twitter API to v1.1

### DIFF
--- a/TwitterBot.pm
+++ b/TwitterBot.pm
@@ -20,7 +20,7 @@ sub said {
 
   # twitter link
   my $twlk = Net::Twitter->new(
-    traits   => [qw/OAuth API::REST/],
+    traits   => [qw/OAuth API::RESTv1_1/],
     consumer_key        => $self->{consumer_key},
     consumer_secret     => $self->{consumer_secret},
     access_token        => $self->{token},


### PR DESCRIPTION
La fin de l'API v1 fut annoncée en janvier dernier avec un fenêtre de 6mois pour permettre une migration progressive et en douceur. L'arrêt complet étant prévue pour juin 2013.
A priori, le changement a opéré ne concerne que le 'traits' au moment de la liaison avec Twitter, les fonctions (update, retweet) ne semblent pas avoir changées.
Pour éviter tout pb, je passe par une PR pour que vous puissiez tester avant de merger.
Merci,
Fred.
