### PR TITLE
Bugfix pour la fonction reply

### DIFF
--- a/TwitterBot.pm
+++ b/TwitterBot.pm
@@ -149,7 +149,7 @@ sub said {
         $self->say(
           who => $msg->{who},
           channel => $msg->{channel},
-          body => "Un peu long, ".length($1)." au lieu de 140..."
+          body => "Un peu long, ".length($2)." au lieu de 140..."
         );
         return;
       }


### PR DESCRIPTION
Sur le reply, la longueur évaluée ne correspond pas à celle affichée.
Exemple :

[09:58]  <feedoo> @reply 506349870450737152 @haum72  Agenda de la semaine : "jeudi du libre" jeudi soir à l'Epicerie du Pré, rdv à partir de 19h || Bonne semaine et bonne rentrée à tous ! haum.org 2/2  Agenda de la semaine : "jeudi du libre" jeudi soir à l'Epicerie du Pré, rdv à partir de 19h || Bonne semaine et bonne rentrée à tous ! haum.org 2/2
[09:58]  <Twaum> Un peu long, 18 au lieu de 140...
